### PR TITLE
Update to version 1.0.0 and clean up descriptions

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -25,7 +25,7 @@ No personal information is collected or stored, including:
 
 - Files are processed in memory only
 - No data is stored after processing completes
-- Uses PyPDF2, PyMuPDF, and Pillow libraries which process everything locally
+- All processing is done locally on the server
 - Generated images are temporary and deleted after processing
 - Your data is not shared with anyone
 

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ author: kalochin
 created_at: '2025-03-04T08:03:44.658609186Z'
 description:
   en_US: Tools for processing PDF content
-  zh_Hans: 利用 PyPDF2 处理 PDF 内容的工具
+  zh_Hans: 处理 PDF 内容的工具
 icon: icon.svg
 label:
   en_US: PDF Process

--- a/provider/pdf_process.yaml
+++ b/provider/pdf_process.yaml
@@ -6,7 +6,7 @@ identity:
   description:
     en_US: Tools for processing PDF content
     pt_BR: Tools for processing PDF content
-    zh_Hans: 利用 PyPDF2 处理 PDF 内容的工具
+    zh_Hans: 处理 PDF 内容的工具
   icon: icon.svg
   label:
     en_US: PDF Process


### PR DESCRIPTION
## Summary
Bump plugin version to 1.0.0 and remove specific library names from user-facing descriptions to keep them library-agnostic.

## Changes

### 🎉 Version Update
- Plugin version: `0.0.4` → `1.0.0`
- Marks stable release after successful PyPDF2 to PyMuPDF migration

### 📝 Description Cleanup
**PRIVACY.md**:
- Changed: "Uses PyPDF2, PyMuPDF, and Pillow libraries which process everything locally"
- To: "All processing is done locally on the server"
- More generic and library-agnostic

**manifest.yaml**:
- Updated Chinese description
- Removed: "利用 PyPDF2 处理 PDF 内容的工具" (using PyPDF2)
- To: "处理 PDF 内容的工具" (tools for processing PDF content)

**provider/pdf_process.yaml**:
- Same Chinese description cleanup
- Keeps descriptions focused on functionality, not implementation

## Rationale
- User-facing descriptions should not expose implementation details
- Library-agnostic descriptions are more maintainable
- Version 1.0.0 signals stable API and completed migration

## Test Plan
- [x] Verify descriptions are accurate and informative
- [x] Verify version number is correct
- [x] No functional changes to code

🤖 Generated with [Claude Code](https://claude.com/claude-code)